### PR TITLE
🔥 fix: 브루노 프로젝트 폴더리스트 호출시 재귀 추가

### DIFF
--- a/src/main/java/moka/brunoviewer/app/model/Directory.java
+++ b/src/main/java/moka/brunoviewer/app/model/Directory.java
@@ -1,5 +1,7 @@
 package moka.brunoviewer.app.model;
 
+import java.util.List;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,4 +11,5 @@ public class Directory {
 	Boolean isBru;
 	private String directoryPath;
 	private String directoryName;
+	List<Directory> subDirectoryList;
 }

--- a/src/main/resources/application-prd.yml
+++ b/src/main/resources/application-prd.yml
@@ -1,0 +1,5 @@
+server:
+  port: 7001
+
+bruno:
+  root-path: C:\work\bruno-project\


### PR DESCRIPTION
# 브루노 프로젝트 폴더리스트 조회 기능 수정

## 🔮 Part
 - [ ] 💻 FE
 - [x] 🚚 BE
 - [ ] 🎨 STYLE
 - [ ] 📄 ETC

## 📜 Changes or Issues
 - 관련이슈 혹은 변경사항을 적어주세요.
> `#` 입력 후 Issue 번호를 입력해 주세요. 

## 🎫 Comment

 - 폴더 및 파일리스트 조회시 전체 조회할 수 있도록 재귀 여부 파라미터를 추가

## 💾 Images or Attachments

> Image : `![이미지이름](이미지링크)`

> File : `[파일이름](파일링크)`


